### PR TITLE
fix: mount code into sass-watch

### DIFF
--- a/.ddev/docker-compose.sass-watch.yaml
+++ b/.ddev/docker-compose.sass-watch.yaml
@@ -2,17 +2,8 @@ services:
   sass-watch:
     container_name: ddev-${DDEV_SITENAME}-sass-watch
     image: michalklempa/dart-sass:latest
-    user: "501:20"
     labels:
-      #com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: $DDEV_APPROOT
     volumes:
-      - type: volume
-        source: sass
-        target: /var/www/html/public/sass
-      - type: volume
-        source: css
-        target: /var/www/html/public/css
-volumes:
-  sass:
-  css:
+      - ..:/var/www/html


### PR DESCRIPTION
This shows how to mount into the container.

There are a number of outstanding problems:

* This image (michalklempa/dart-sass) is available only for AMD64, meaning that your team members on macOS or new ARM64 Windows will have trouble with it.
* The image only knows how to run as root, which may mean that your compiled css will have the wrong permissions.